### PR TITLE
Revert "add temporary run_constrained for autopep8"

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,7 +6,7 @@
 # this will likely have to be hand-updated.
 {% set server_version = "1.5.1" %}
 # Leave the build number the same if only the labextension changes.
-{% set server_build_number = 0 %}
+{% set server_build_number = 1 %}
 
 # List of jupyter_lsp py.tests ran for each known servers
 {% set server_tests = ["serverextension", "start_known", "listeners"] %}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -147,9 +147,6 @@ outputs:
       run:
         - {{ pin_subpackage("jupyter-lsp", exact=True) }}
         - python-lsp-server >=1
-      run_constrained:
-        # TODO: probably can remove this after a few builds, see #35
-        - autopep8 !=1.6.0=*_0
     test:
       requires:
         - pip


### PR DESCRIPTION
This reverts commit 7f953f72cc0db32d9f7eecf8a6983abef24cfff3.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
